### PR TITLE
Add guild_name alias as `server`

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -264,6 +264,7 @@ pub fn create_guild_buffer(id: GuildId, name: &str) {
         let buffer = find_or_make_buffer(&weechat, &guild_name_id);
 
         buffer.set_localvar("guild_name", name);
+        buffer.set_localvar("server", name);
         buffer.set_short_name(name);
         buffer.set_localvar("guildid", &id.0.to_string());
         buffer.set_localvar("type", "server");
@@ -309,6 +310,7 @@ pub fn create_buffer_from_channel(
         buffer.set_localvar("guildid", &channel.guild_id.0.to_string());
         buffer.set_localvar("channel_name", &channel.name);
         buffer.set_localvar("guild_name", guild_name);
+        buffer.set_localvar("server", guild_name);
         buffer.set_localvar("type", channel_type);
         buffer.set_localvar("nick", &nick);
         if has_unread && !muted {


### PR DESCRIPTION
This seems to be the standard with weechat things.

I specifically need to be able to query `${server}` so that I can use [autosort.py](https://weechat.org/scripts/source/autosort.py.html/) effectively.

irc, slack & matrix all have it available to use, even though it doesn't map *directly* onto discord's architecture.

Related: #50