### PR TITLE
Update weechat and weechat-sys dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "weechat"
 version = "0.1.0"
-source = "git+https://github.com/terminal-discord/rust-weechat?rev=a82ade0#a82ade081343f557ba2a77cedd1fc373b8737db5"
+source = "git+https://github.com/terminal-discord/rust-weechat?rev=d0365fc#d0365fc26847b6c5dd4cde29a5b966d3141548d1"
 dependencies = [
  "chrono",
  "libc",
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "weechat-macro"
 version = "0.1.0"
-source = "git+https://github.com/terminal-discord/rust-weechat?rev=a82ade0#a82ade081343f557ba2a77cedd1fc373b8737db5"
+source = "git+https://github.com/terminal-discord/rust-weechat?rev=d0365fc#d0365fc26847b6c5dd4cde29a5b966d3141548d1"
 dependencies = [
  "libc",
  "proc-macro2",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "weechat-sys"
 version = "0.1.0"
-source = "git+https://github.com/terminal-discord/rust-weechat?rev=a82ade0#a82ade081343f557ba2a77cedd1fc373b8737db5"
+source = "git+https://github.com/terminal-discord/rust-weechat?rev=d0365fc#d0365fc26847b6c5dd4cde29a5b966d3141548d1"
 dependencies = [
  "bindgen",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ path = "parsing"
 
 [dependencies.weechat]
 git = "https://github.com/terminal-discord/rust-weechat"
-rev = "a82ade0"
+rev = "d0365fc"
 
 [dependencies.weechat-sys]
 git = "https://github.com/terminal-discord/rust-weechat"
-rev = "a82ade0"
+rev = "d0365fc"
 
 #[patch."https://github.com/terminal-discord/rust-weechat"]
 #weechat-sys = { path = "../rust-weechat/weechat-sys" }


### PR DESCRIPTION
The current iteration on master isn't compatible with API version 20210601-01, used by Weechat 3.2. Bumping the weechat and weechat-sys commit fixes this, and I haven't seen any other breakage after a couple days of use.